### PR TITLE
Serverless support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM maven:3.6.3-jdk-8
+COPY --from=public.ecr.aws/m7b0o7h1/secret-env-vars-wrapper:latest-x86 /opt /opt
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.3.2-x86_64 /lambda-adapter /opt/extensions/lambda-adapter
 
-EXPOSE 80
+EXPOSE 8000
 
 COPY . .
 
 RUN mvn clean package -DskipTests
  
-CMD ["java", "-jar", "target/spring-boot-0.0.1-SNAPSHOT.jar"]
+CMD ["/opt/tinystacks-secret-env-vars-wrapper", "java", "-jar", "target/spring-boot-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM maven:3.6.3-jdk-8
-COPY --from=public.ecr.aws/m7b0o7h1/secret-env-vars-wrapper:latest-x86 /opt /opt
+COPY --from=public.ecr.aws/tinystacks/secret-env-vars-wrapper:latest-x86 /opt /opt
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.3.2-x86_64 /lambda-adapter /opt/extensions/lambda-adapter
 
 EXPOSE 8000

--- a/release.yml
+++ b/release.yml
@@ -9,5 +9,19 @@ phases:
   post_build:
     on-failure: CONTINUE
     commands:
-      - region="${STAGE_REGION:-$AWS_REGION}"
-      - if [ -z "$SERVICE_NAME" ] || [ "$SERVICE_NAME" == "placeholder" ]; then echo 'Service is not ready yet. Repository tagged correctly, exiting now'; else  aws ecs update-service --service $SERVICE_NAME --cluster $CLUSTER_ARN --region $region --force-new-deployment; fi
+      - region="${STAGE_REGION:-$AWS_REGION}" 
+      - |
+        if [ ! -z "$LAMBDA_FUNCTION_NAME" -a  "$LAMBDA_FUNCTION_NAME" != "placeholder" ];
+          then
+            aws lambda update-function-code --function-name "$LAMBDA_FUNCTION_NAME" --image-uri "$ECR_IMAGE_URL:$STAGE_NAME" --region $region
+            imageSha=$(docker images --no-trunc --quiet $ECR_IMAGE_URL:$PREVIOUS_STAGE_NAME);
+            aws lambda tag-resource --resource "$LAMBDA_FUNCTION_ARN" --tags "IMAGE_SHA=$imageSha"
+          else
+            echo 'Not a serverless stage'
+            if [ -z "$SERVICE_NAME" ] || [ "$SERVICE_NAME" == "placeholder" ];
+              then
+                echo 'Service is not ready yet. Repository tagged correctly, exiting now';
+              else
+                aws ecs update-service --service $SERVICE_NAME --cluster $CLUSTER_ARN --region $region --force-new-deployment;
+            fi
+        fi


### PR DESCRIPTION
This PR includes the following changes in order to support serverless hosting on lambda:
1. Include two lambda extensions in Dockerfile
    - One for adapting to Lambda events
    - One for Secrets Manager support
2. Update release.yml
3. Change default port
    - port 80 cannot be used on Lambda (no privileged port can be used i.e. below 1024)